### PR TITLE
About: fix portrait to 200x200 with responsive wrap

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -177,27 +177,30 @@ body {
 .hidden { display: none; }
 
 /* About photo */
-.about-photo { 
-  float: right; 
-  width: clamp(140px, 28vw, 240px); 
-  margin: 4px 0 10px 18px; 
-  shape-outside: inset(0 round 16px); 
-  shape-margin: 12px; 
+.about-photo {
+  float: right;
+  width: 200px;
+  height: 200px;
+  margin: 2px 0 10px 18px;
+  shape-outside: inset(0 round 16px);
+  shape-margin: 12px;
 }
-.about-photo img { 
-  display: block; 
-  width: 100%; 
-  height: auto; 
-  border-radius: 16px; 
-  border: 1px solid var(--border); 
-  background: color-mix(in oklab, var(--panel) 85%, transparent); 
+.about-photo img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: color-mix(in oklab, var(--panel) 85%, transparent);
   box-shadow: 0 14px 36px -18px rgba(2, 6, 23, .65);
 }
-@media (max-width: 920px) { 
-  .about-photo { 
-    float: none; 
-    margin: 0 auto 14px; 
-    width: min(60%, 240px); 
+@media (max-width: 920px) {
+  .about-photo {
+    float: none;
+    margin: 0 auto 14px;
+    width: 200px;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
- Sets the About portrait to a fixed 200x200 with float-right and shape-outside for elegant text wrap.\n- Keeps rounded corners, subtle border, and shadow for consistency.\n- On small screens, stacks above text centered at the same size.\n\nThis follows up on the merged selfie-reveal PR, putting the size tweak in its own branch/PR.