### PR TITLE
Swap header monogram for SVG logo

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -72,8 +72,15 @@ body {
 .site-header { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(8px); background: color-mix(in oklab, var(--bg) 80%, transparent); border-bottom: 1px solid var(--border); }
 .header-inner { display: flex; align-items: center; height: 64px; }
 .brand { display: flex; align-items: center; gap: 10px; font-weight: 800; letter-spacing: .2px; }
-.logo { display: inline-block; width: 32px; height: 32px; border-radius: 8px; }
-.k-logo { display: inline-flex; align-items: center; justify-content: center; font-weight: 800; font-size: 18px; color: #fff; background: linear-gradient(135deg, var(--accent-start), var(--accent-end)); }
+.logo {
+  display: block;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+  object-fit: cover;
+}
 .name { opacity: .9; }
 .nav { margin-left: auto; display: flex; gap: 14px; align-items: center; }
 .nav a { color: var(--text); text-decoration: none; opacity: .9; padding: 8px 10px; border-radius: 8px; }

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
   <body>
     <header class="site-header">
       <div class="container header-inner">
-          <div class="brand">
-          <span class="logo k-logo" aria-hidden="true">K</span>
+        <div class="brand">
+          <img class="logo" src="assets/k-logo.svg" alt="" />
           <span class="name">kamoore</span>
         </div>
         <nav class="nav">


### PR DESCRIPTION
## Summary
- replace the placeholder header initial with the k-logo.svg artwork
- adjust header logo styling so the SVG scales cleanly within the existing brand lockup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4d042eed0832299aafbee2e448a7f